### PR TITLE
Feat: add meta attributes

### DIFF
--- a/oca-ast/src/ast.rs
+++ b/oca-ast/src/ast.rs
@@ -1,7 +1,7 @@
 use indexmap::IndexMap;
 use serde::{Serialize, Serializer, Deserialize, Deserializer};
 use strum_macros::Display;
-use std::str::FromStr;
+use std::{str::FromStr, collections::HashMap};
 use wasm_bindgen::prelude::*;
 
 
@@ -10,6 +10,7 @@ pub struct OCAAst {
     pub version: String,
     pub commands: Vec<Command>,
     pub commands_meta: IndexMap<usize, CommandMeta>,
+    pub meta: HashMap<String, String>
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
@@ -281,6 +282,7 @@ impl OCAAst {
             version: String::from("1.0.0"),
             commands: Vec::new(),
             commands_meta: IndexMap::new(),
+            meta: HashMap::new(),
         }
     }
 }

--- a/oca-bundle/src/build.rs
+++ b/oca-bundle/src/build.rs
@@ -671,6 +671,7 @@ mod tests {
             version: "1.0".to_string(),
             commands,
             commands_meta: IndexMap::new(),
+            meta: HashMap::new(),
         };
 
         let build_result = from_ast(None, oca_ast);

--- a/oca-dag/src/lib.rs
+++ b/oca-dag/src/lib.rs
@@ -270,6 +270,7 @@ mod tests {
             version: "0.1.0".to_string(),
             commands,
             commands_meta: IndexMap::new(),
+            meta: HashMap::new(),
         };
         let oca_build = oca_bundle::build::from_ast(None, ast).unwrap();
 

--- a/oca-file/src/ocafile.pest
+++ b/oca-file/src/ocafile.pest
@@ -171,19 +171,20 @@ attr_entry_key_pairs = ${ (arg_ws? ~ entry_key_pair ~ arg_ws?)+ }
 list_value = ${ (arg_ws? ~ key_value ~ arg_ws?)+ }
 unit_system = ${ (ASCII_ALPHANUMERIC | "-" | "_")+ }
 
-attr_type = ${ ("Text" |
-              "Numeric" |
-              "Reference" |
-              "Boolean" |
-              "Binary" |
-              "DateTime" |
-              "Array[Text]" |
-              "Array[Numeric]" |
-              "Array[Reference]" |
-              "Array[Boolean]" |
-              "Array[Binary]" |
-              "Array[DateTime]" )}
-attr_pair = @{attr_key ~ "=" ~ attr_type}
+attr_type = @{ ("Text" |
+        "Numeric" |
+        "Boolean" |
+        "Binary" |
+        "DateTime" |
+        "Array[Text]" |
+        "Array[Numeric]" |
+        "Array[Boolean]" |
+        "Array[Binary]" |
+        "Array[DateTime]" )}
+reference = @{ char+ }
+said = @{ char+ }
+_attr_type = ${ attr_type | (^"refs:" ~ said) | (^"refn:" ~ reference) }
+attr_pair = @{attr_key ~ "=" ~ _attr_type}
 attr_pairs = ${ (arg_ws ~ attr_pair)+}
 
 lang = ${ ASCII_ALPHA{2} ~ ("-" ~ ASCII_ALPHA{2})? }

--- a/oca-file/src/ocafile.pest
+++ b/oca-file/src/ocafile.pest
@@ -4,6 +4,12 @@
 // insignificant whitespace, not repeated
 ws = _{ " " | "\t" }
 
+meta_attr_key = ${ "name" | "version" }
+meta_attr_value = ${ string | char+}
+meta_key_pair = @{ meta_attr_key ~ "=" ~ meta_attr_value }
+meta_comment = @{ "--" ~ ws* ~ (!NEWLINE ~ meta_key_pair)* }
+meta_comment_line = _{ ws* ~ meta_comment ~ NEWLINE? }
+
 comment = @{ "#" ~ (!NEWLINE ~ ANY)* }
 comment_line = _{ ws* ~ comment ~ NEWLINE? }
 empty_line = @{ ws* ~ NEWLINE }
@@ -191,6 +197,6 @@ lang = ${ ASCII_ALPHA{2} ~ ("-" ~ ASCII_ALPHA{2})? }
 
 file = {
   SOI ~
-  (empty_line | comment_line | commands)*
+  (empty_line | meta_comment_line | comment_line | commands)*
   ~ EOI
 }

--- a/oca-file/src/ocafile/instructions/add.rs
+++ b/oca-file/src/ocafile/instructions/add.rs
@@ -47,6 +47,7 @@ impl AddInstruction {
                             }
                         }
                     }
+                    debug!("Attributes: {:?}", attributes);
                     Some(Content {
                         properties: None,
                         attributes: Some(attributes),
@@ -147,6 +148,8 @@ mod tests {
     fn test_add_attribute_instruction() {
         // test vector with example instruction and boolean if they should be valid or not
         let instructions = vec![
+            ("ADD ATTRIBUTE documentNumber=snieg documentType=refs:12d1j02dj1092dj1092jd1092", false),
+            ("ADD ATTRIBUTE documentNumber=refn:snieg documentType=refs:12d1j02dj1092dj1092jd1092", true),
             ("ADD ATTRIBUTE documentNumber=Text documentType=Numeric", true),
             ("ADD ATTRIBUTE documentNumber=Text documentType=Numeric name=Text list=Array[Numeric]", true),
             ("ADD ATTRIBUTE name=Text", false),
@@ -155,6 +158,7 @@ mod tests {
             ("add attribute name=Text", true),
             ("add attribute name=Random", false),
         ];
+        let _ = env_logger::builder().is_test(true).try_init();
 
         // loop over instructions to check if the are meeting the requirements
         for (instruction, is_valid) in instructions {

--- a/oca-file/src/ocafile/instructions/add.rs
+++ b/oca-file/src/ocafile/instructions/add.rs
@@ -24,18 +24,18 @@ impl AddInstruction {
                     for attr_pairs in object.into_inner() {
                         match attr_pairs.as_rule() {
                             Rule::attr_pairs => {
-                                info!("attribute: {:?}", attr_pairs);
+                                debug!("Attribute pairs: {:?}", attr_pairs);
                                 for attr in attr_pairs.into_inner() {
-                                    debug!("Parsing attribute {:?}", attr);
+                                    debug!("Parsing attribute pair {:?}", attr);
                                     if let Some((key, value)) =
                                         helpers::extract_attribute_key_pairs(attr)
                                     {
-                                        debug!("Parsed attribute: {:?} = {:?}", key, value);
+                                        info!("Parsed attribute: {:?} = {:?}", key, value);
 
                                         // TODO find out how to parse nested objects
                                         attributes.insert(key, value);
                                     } else {
-                                        debug!("Skipping attribute");
+                                        debug!("Attribute skipped");
                                     }
                                 }
                             }

--- a/oca/src/facade/fetch.rs
+++ b/oca/src/facade/fetch.rs
@@ -321,6 +321,19 @@ impl Facade {
                                     if let oca_ast::ast::NestedValue::Value(value) = value {
                                         line.push_str(format!("{}={} ", key, value).as_str());
                                     }
+                                    if let oca_ast::ast::NestedValue::Reference(value) = value {
+                                        match value {
+                                            oca_ast::ast::RefValue::Name(refn) => {
+                                                line.push_str(format!("{}=refn:{} ", key, refn).as_str());
+                                            }
+                                            oca_ast::ast::RefValue::Said(refs) => {
+                                                line.push_str(format!("{}=refs:{} ", key, refs).as_str());
+                                            }
+
+                                        }
+                                    }
+                                    // TODO handle Array and object?
+
                                 });
                             }
                         };


### PR DESCRIPTION
add meta attributes into ast model
add new syntax to ocafile supporting meta attributes:

- name - name of the object which can be used as referance
- version - version of DSL language in OCAFILE
