### PR TITLE
fix: Serialize reference to refs

### DIFF
--- a/oca-ast/src/ast.rs
+++ b/oca-ast/src/ast.rs
@@ -86,7 +86,7 @@ impl FromStr for AttributeType {
             "Array[Reference]" => Ok(AttributeType::ArrayReference),
             _ => {
                 if let Some((attr_type, _)) = s.split_once(':') {
-                    if attr_type == "Reference" {
+                    if attr_type == "refs" {
                         Ok(AttributeType::Reference)
                     } else if attr_type == "Array[Reference" {
                         Ok(AttributeType::ArrayReference)

--- a/oca-ast/src/ast.rs
+++ b/oca-ast/src/ast.rs
@@ -61,6 +61,7 @@ pub enum AttributeType {
     DateTime,
     #[serde(rename = "Array[DateTime]")]
     ArrayDateTime,
+    #[serde(rename = "refs")]
     Reference,
     #[serde(rename = "Array[Reference]")]
     ArrayReference,

--- a/oca/tests/build_from_ocafile.rs
+++ b/oca/tests/build_from_ocafile.rs
@@ -64,6 +64,7 @@ ADD ATTRIBUTE x=Text
         Ok(())
     }
 
+    #[cfg(feature = "local-references")]
     #[test]
     fn build_with_references() -> Result<(), Vec<Error>> {
         let db = InMemoryDataStorage::new();
@@ -89,7 +90,7 @@ ADD ATTRIBUTE B=refn:other
 
         assert_eq!(
             result.said.unwrap().to_string(),
-            "EPZNx7Vbl06cYdsAKbRVtgxUOoLcap61Go7ueau1RjEN"
+            "ELxZNFB5vW8_wDKLsAyAiX2AdsiNIHuw_1ZakI7LBbgd"
         );
         Ok(())
     }


### PR DESCRIPTION
To keep compatibility with OCAFile syntax keep serialization in refs (reference-said)