### PR TITLE
fix(oca-ast): remove object from NestedAttrType

### DIFF
--- a/oca-ast/src/ast/attributes.rs
+++ b/oca-ast/src/ast/attributes.rs
@@ -1,4 +1,3 @@
-use indexmap::IndexMap;
 use recursion::{
     Collapsible, Expandable, ExpandableExt, MappableFrame, PartiallyApplied,
 };
@@ -150,7 +149,6 @@ impl<'de> Deserialize<'de> for NestedAttrType {
 
 #[cfg(test)]
 mod tests {
-    use indexmap::IndexMap;
     use said::derivation::{HashFunction, HashFunctionCode};
 
     use crate::ast::{AttributeType, NestedAttrType, RefValue};

--- a/oca-ast/src/ast/attributes.rs
+++ b/oca-ast/src/ast/attributes.rs
@@ -25,7 +25,6 @@ use super::{AttributeType, RefValue, error::AttributeError, nested_result::{Nest
 pub enum NestedAttrType {
     Reference(RefValue),
     Value(AttributeType),
-    Object(IndexMap<String, NestedAttrType>),
     #[serde(serialize_with = "array_serializer")]
     Array(Box<NestedAttrType>),
     /// Indicator that attribute was removed and does not need any type
@@ -68,12 +67,6 @@ impl Hash for NestedAttrType {
             NestedAttrType::Value(attr_type) => {
                 attr_type.hash(state);
             }
-            NestedAttrType::Object(object) => {
-                for (key, value) in object {
-                    key.hash(state);
-                    value.hash(state);
-                }
-            }
             NestedAttrType::Array(array) => {
                 array.hash(state);
             }
@@ -87,7 +80,6 @@ impl Hash for NestedAttrType {
 pub enum NestedAttrTypeFrame<A> {
     Reference(RefValue),
     Value(AttributeType),
-    Object(IndexMap<String, A>),
     Array(A),
     Null,
 }
@@ -99,13 +91,6 @@ impl MappableFrame for NestedAttrTypeFrame<PartiallyApplied> {
         match input {
             NestedAttrTypeFrame::Reference(reference) => NestedAttrTypeFrame::Reference(reference),
             NestedAttrTypeFrame::Value(val) => NestedAttrTypeFrame::Value(val),
-            NestedAttrTypeFrame::Object(obj) => {
-                let obj = obj
-                    .into_iter()
-                    .map(|(key, value)| (key, f(value)))
-                    .collect();
-                NestedAttrTypeFrame::Object(obj)
-            }
             NestedAttrTypeFrame::Array(t) => NestedAttrTypeFrame::Array(f(t)),
             NestedAttrTypeFrame::Null => NestedAttrTypeFrame::Null,
         }
@@ -119,7 +104,6 @@ impl Expandable for NestedAttrType {
         match val {
             NestedAttrTypeFrame::Reference(reference) => NestedAttrType::Reference(reference),
             NestedAttrTypeFrame::Value(v) => NestedAttrType::Value(v),
-            NestedAttrTypeFrame::Object(obj) => NestedAttrType::Object(obj),
             NestedAttrTypeFrame::Array(arr) => NestedAttrType::Array(Box::new(arr)),
             NestedAttrTypeFrame::Null => NestedAttrType::Null,
         }
@@ -133,7 +117,6 @@ impl Collapsible for NestedAttrType {
         match self {
             NestedAttrType::Reference(reference) => NestedAttrTypeFrame::Reference(reference),
             NestedAttrType::Value(val) => NestedAttrTypeFrame::Value(val),
-            NestedAttrType::Object(obj) => NestedAttrTypeFrame::Object(obj),
             NestedAttrType::Array(arr) => NestedAttrTypeFrame::Array(*arr),
             NestedAttrType::Null => NestedAttrTypeFrame::Null,
         }
@@ -155,13 +138,6 @@ impl<'de> Deserialize<'de> for NestedAttrType {
                     Err(_) => NestedResultFrame(Err(AttributeError::General(format!("Can't parse attribute type: {}", text)))),
                 },
             },
-            serde_json::Value::Object(obj) => {
-                let mut idx_map = IndexMap::new();
-                for (key, value) in obj {
-                    idx_map.insert(key, value);
-                }
-                NestedResultFrame(Ok(NestedAttrTypeFrame::Object(idx_map)))
-            }
             serde_json::Value::Array(arr) => NestedResultFrame(Ok(NestedAttrTypeFrame::Array(arr[0].clone()))),
             e => NestedResultFrame(Err(AttributeError::General(format!("Unexpected json value: {}", e.to_string())))),
         });
@@ -181,36 +157,17 @@ mod tests {
 
 
     #[test]
-    fn test_nested_attribute_serialize() {
-        let mut object_example = IndexMap::new();
-        let mut person = IndexMap::new();
-        person.insert(
-            "name".to_string(),
-            NestedAttrType::Value(AttributeType::Text),
-        );
+    fn test_nested_array_attribute_type_serialization() {
 
-        let arr = NestedAttrType::Array(Box::new(NestedAttrType::Value(AttributeType::Boolean)));
-        object_example.insert("allowed".to_string(), arr);
-
-        object_example.insert(
-            "test".to_string(),
-            NestedAttrType::Value(AttributeType::Text),
-        );
-        object_example.insert("person".to_string(), NestedAttrType::Object(person));
+        let arr = NestedAttrType::Array(Box::new(NestedAttrType::Array(Box::new(NestedAttrType::Value(AttributeType::Boolean)))));
         let said = HashFunction::from(HashFunctionCode::Blake3_256).derive("fff".as_bytes());
-        object_example.insert(
-            "ref".to_string(),
-            NestedAttrType::Reference(RefValue::Said(said.clone())),
-        );
 
-        let attributes = NestedAttrType::Object(object_example);
-
-        let serialized = serde_json::to_string(&attributes).unwrap();
-        let expected = r#"{"allowed":["Boolean"],"test":"Text","person":{"name":"Text"},"ref":"refs:EEokfxxqwAM08iku7VHMaVFBaEGYVi2W-ctBKaTW6QdJ"}"#;
+        let serialized = serde_json::to_string(&arr).unwrap();
+        let expected = r#"[["Boolean"]]"#;
         assert_eq!(expected, serialized);
 
         let deser: NestedAttrType = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(attributes, deser);
+        assert_eq!(arr, deser);
 
         let attributes =
             NestedAttrType::Array(Box::new(NestedAttrType::Reference(RefValue::Said(said))));

--- a/oca-ast/src/ast/mod.rs
+++ b/oca-ast/src/ast/mod.rs
@@ -947,11 +947,6 @@ mod tests {
     fn test_ocaast_serialize() {
         let mut attributes = IndexMap::new();
         let mut properties = IndexMap::new();
-        let mut person = IndexMap::new();
-        person.insert(
-            "name".to_string(),
-            NestedAttrType::Value(AttributeType::Text),
-        );
 
         let arr = NestedAttrType::Array(Box::new(NestedAttrType::Value(AttributeType::Boolean)));
         attributes.insert("allowed".to_string(), arr);
@@ -986,7 +981,7 @@ mod tests {
         let serialized = serde_json::to_string(&ocaast).unwrap();
         assert_eq!(
             serialized,
-            r#"{"version":"1.0.0","commands":[{"type":"Add","object_kind":"CaptureBase","content":{"attributes":{"allowed":["Boolean"],"test":"Text"},"properties":{"test":"test"}}},{"type":"Add","object_kind":"Label","content":{}}],"commands_meta":{},"meta":{}}"# // r#"{"version":"1.0.0","commands":[{"type":"Add","object_kind":"CaptureBase","content":{"attributes":{"test":"Text","person":{"name":"Text"}},"properties":{"test":"test"}}},{"type":"Add","object_kind":"Label","content":{}}],"commands_meta":{},"meta":{}}"#
+            r#"{"version":"1.0.0","commands":[{"type":"Add","object_kind":"CaptureBase","content":{"attributes":{"allowed":["Boolean"],"test":"Text"},"properties":{"test":"test"}}},{"type":"Add","object_kind":"Label","content":{}}],"commands_meta":{},"meta":{}}"# 
         );
 
         let deser: OCAAst = serde_json::from_str(&serialized).unwrap();

--- a/oca-ast/src/ast/mod.rs
+++ b/oca-ast/src/ast/mod.rs
@@ -959,7 +959,6 @@ mod tests {
             "test".to_string(),
             NestedAttrType::Value(AttributeType::Text),
         );
-        attributes.insert("person".to_string(), NestedAttrType::Object(person));
         properties.insert("test".to_string(), NestedValue::Value("test".to_string()));
         let command = Command {
             kind: CommandType::Add,
@@ -987,7 +986,7 @@ mod tests {
         let serialized = serde_json::to_string(&ocaast).unwrap();
         assert_eq!(
             serialized,
-            r#"{"version":"1.0.0","commands":[{"type":"Add","object_kind":"CaptureBase","content":{"attributes":{"allowed":["Boolean"],"test":"Text","person":{"name":"Text"}},"properties":{"test":"test"}}},{"type":"Add","object_kind":"Label","content":{}}],"commands_meta":{},"meta":{}}"# // r#"{"version":"1.0.0","commands":[{"type":"Add","object_kind":"CaptureBase","content":{"attributes":{"test":"Text","person":{"name":"Text"}},"properties":{"test":"test"}}},{"type":"Add","object_kind":"Label","content":{}}],"commands_meta":{},"meta":{}}"#
+            r#"{"version":"1.0.0","commands":[{"type":"Add","object_kind":"CaptureBase","content":{"attributes":{"allowed":["Boolean"],"test":"Text"},"properties":{"test":"test"}}},{"type":"Add","object_kind":"Label","content":{}}],"commands_meta":{},"meta":{}}"# // r#"{"version":"1.0.0","commands":[{"type":"Add","object_kind":"CaptureBase","content":{"attributes":{"test":"Text","person":{"name":"Text"}},"properties":{"test":"test"}}},{"type":"Add","object_kind":"Label","content":{}}],"commands_meta":{},"meta":{}}"#
         );
 
         let deser: OCAAst = serde_json::from_str(&serialized).unwrap();

--- a/oca-ast/src/ast/nested_result.rs
+++ b/oca-ast/src/ast/nested_result.rs
@@ -24,7 +24,6 @@ impl Expandable for NestedResult {
         let val = match val.0  {
             Ok(NestedAttrTypeFrame::Value(v)) => {NestedAttrType::Value(v)},
             Ok(NestedAttrTypeFrame::Reference(r)) => {NestedAttrType::Reference(r)},
-            Ok(NestedAttrTypeFrame::Object(o)) => todo!(),
             Ok(NestedAttrTypeFrame::Array(v)) => {
 				match v.0 {
 					Ok(ok) => NestedAttrType::Array(Box::new(ok)),

--- a/oca-bundle/src/state/validator.rs
+++ b/oca-bundle/src/state/validator.rs
@@ -238,6 +238,7 @@ impl Validator {
                             AttributeType::Boolean => "true".to_string(),
                         }
                     }
+                    // TODO validate nested objects
                     NestedAttrType::Array(boxed_type) =>  {
                         match **boxed_type {
                             NestedAttrType::Value(base_type) => match base_type {
@@ -249,9 +250,6 @@ impl Validator {
                             },
                             _ => panic!("Invalid or not supported array type"),
                         }
-                    },
-                    NestedAttrType::Object(_) => {
-                        panic!("Invalid or not supported object type")
                     },
                     NestedAttrType::Reference(ref_value) => {
                         ref_value.to_string()

--- a/oca-file/src/ocafile.pest
+++ b/oca-file/src/ocafile.pest
@@ -209,10 +209,7 @@ base_attr_type = @{ ("Text" |
         "Binary" |
         "DateTime" )}
 
-object_attr_type = @{( "Object("~ arg_ws? ~ "{" ~ arg_ws? ~ (attr_key ~ "=" ~ _attr_type ~ ("," ~ arg_ws_maybe)?)+ ~ arg_ws_maybe ~ "})")}
-
-// TODO find out if we could have just array and then types
-array_attr_type = ${( "Array["~ (base_attr_type | array_attr_type | reference_type | object_attr_type ) ~"]" )}
+array_attr_type = ${( "Array["~ (base_attr_type | reference_type | array_attr_type ) ~"]" )}
 reference_type = _{ ref_said | ref_alias }
 alias = @{ char+ }
 said = @{ char+ }
@@ -220,7 +217,7 @@ refs = _{^"refs:"}
 refn = _{^"refn:"}
 ref_said = _{ refs ~ said}
 ref_alias = _{ refn ~ alias }
-_attr_type = ${ base_attr_type | array_attr_type | ref_said | ref_alias | object_attr_type }
+_attr_type = ${ base_attr_type | array_attr_type | ref_said | ref_alias }
 attr_pair = @{attr_key ~ "=" ~ _attr_type}
 attr_pairs = ${ (arg_ws ~ attr_pair)+}
 

--- a/oca-file/src/ocafile/instructions/helpers.rs
+++ b/oca-file/src/ocafile/instructions/helpers.rs
@@ -25,25 +25,11 @@ fn extract_attr_type(input: Pair) -> NestedAttrType {
                 let attr_type = AttributeType::from_str(seed.as_span().as_str()).unwrap();
                 NestedAttrTypeFrame::Value(attr_type)
             },
-            Rule::object_attr_type => {
-                NestedAttrTypeFrame::Object(extract_object(seed))
-            },
             r => {
                 panic!("Matching attr type didn't work. Unhandled Rule type: {:?}", r);
             }
         }
     })
-}
-
-fn extract_object(input_pair: Pair) -> IndexMap<String, Pair> {
-    let mut object_fields = input_pair.into_inner();
-    let mut idmap = IndexMap::new();
-    while let Some(field) = object_fields.next() {
-        let key = field.as_span().as_str().to_owned();
-        let value = object_fields.next().unwrap();
-        idmap.insert(key, value);
-    };
-    idmap
 }
 
 pub fn extract_attribute(attr_pair: Pair) -> Option<(String, NestedAttrType)> {


### PR DESCRIPTION
Object is replaced with references, this avoids ambiguity in regards of data representation. It follows the official OCA 1.0 specfication where obejct is always an ref.