### PR TITLE
 Refactor OCA file validation logic

### DIFF
--- a/oca-bundle/src/state/oca/overlay/conditional.rs
+++ b/oca-bundle/src/state/oca/overlay/conditional.rs
@@ -3,9 +3,7 @@ use oca_ast::ast::OverlayType;
 use piccolo::{Closure, Lua, Thread};
 use said::{sad::SerializationFormats, sad::SAD};
 use serde::{Deserialize, Serialize};
-use std::{
-    any::Any, collections::BTreeMap, error::Error as StdError, fmt::Display,
-};
+use std::{any::Any, collections::BTreeMap, error::Error as StdError, fmt::Display};
 
 pub trait Conditionals {
     fn set_condition(&mut self, condition: String);
@@ -62,9 +60,7 @@ impl Conditionals for Attribute {
         }
         condition_dependencies.iter().for_each(|d| {
             if !dependency_values.contains_key(d) {
-                errors.push(Error::Custom(format!(
-                    "Missing dependency '{d}' value",
-                )));
+                errors.push(Error::Custom(format!("Missing dependency '{d}' value",)));
             }
         });
 
@@ -75,11 +71,7 @@ impl Conditionals for Attribute {
         let script = re
             .replace_all(condition, |caps: &regex::Captures| {
                 dependency_values
-                    .get(
-                        &condition_dependencies
-                            [caps[1].parse::<usize>().unwrap()]
-                        .clone(),
-                    )
+                    .get(&condition_dependencies[caps[1].parse::<usize>().unwrap()].clone())
                     .unwrap()
                     .to_string()
             })
@@ -87,8 +79,7 @@ impl Conditionals for Attribute {
 
         let mut lua = Lua::new();
         let thread_result = lua.try_run(|ctx| {
-            let closure =
-                Closure::load(ctx, format!("return {script}").as_bytes())?;
+            let closure = Closure::load(ctx, format!("return {script}").as_bytes())?;
             let thread = Thread::new(&ctx);
             thread.start(ctx, closure.into(), ())?;
             Ok(ctx.state.registry.stash(&ctx, thread))
@@ -258,10 +249,8 @@ mod tests {
                 ..set_condition(condition.to_string());
             };
 
-            let mut dependency_values: BTreeMap<
-                String,
-                Box<dyn Display + 'static>,
-            > = BTreeMap::new();
+            let mut dependency_values: BTreeMap<String, Box<dyn Display + 'static>> =
+                BTreeMap::new();
             let mut dependency_values_str = vec![];
             for value in values.into_iter() {
                 dependency_values_str.push(format!("{:?}", value));

--- a/oca/src/facade/build.rs
+++ b/oca/src/facade/build.rs
@@ -31,6 +31,10 @@ pub enum Error {
         #[serde(rename = "e")]
         message: String,
     },
+    #[cfg(feature = "local-references")]
+    #[error("Reference {0} not found")]
+    UnknownRefn(String)
+    
 }
 
 impl Facade {
@@ -93,7 +97,7 @@ impl Facade {
         // Dereference (refn -> refs) the AST before it start processing bundle steps, otherwise the SAID would
         // not match.
         #[cfg(feature = "local-references")]
-        local_references::replace_refn_with_refs(&mut oca_ast, references);
+        local_references::replace_refn_with_refs(&mut oca_ast, references).map_err(|e| vec![e])?;
 
         let oca_build = oca_bundle::build::from_ast(base, &oca_ast).map_err(|e| {
             e.iter()

--- a/oca/src/facade/build.rs
+++ b/oca/src/facade/build.rs
@@ -17,6 +17,7 @@ use oca_bundle::state::oca::OCABundle;
 use oca_bundle::Encode;
 use oca_dag::build_core_db_model;
 
+use std::borrow::Borrow;
 use std::rc::Rc;
 
 #[derive(thiserror::Error, Debug, serde::Serialize)]
@@ -63,7 +64,7 @@ impl References for Box<dyn DataStorage> {
 
 impl Facade {
     fn parse_and_check_base(
-        storage: &Box<dyn DataStorage>,
+        storage: &dyn DataStorage,
         ocafile: String,
     ) -> Result<(Option<OCABundle>, OCAAst), Vec<ValidationError>> {
         let mut errors: Vec<ValidationError> = vec![];
@@ -149,7 +150,7 @@ impl Facade {
 
     #[cfg(feature = "local-references")]
     pub fn validate_ocafile<R: References>(
-        storage: &Box<dyn DataStorage>,
+        storage: &dyn DataStorage,
         ocafile: String,
         references: &mut R,
     ) -> Result<OCABuild, Vec<ValidationError>> {
@@ -159,7 +160,7 @@ impl Facade {
 
     #[cfg(not(feature = "local-references"))]
     pub fn validate_ocafile(
-        storage: &Box<dyn DataStorage>,
+        storage: &dyn DataStorage,
         ocafile: String,
     ) -> Result<OCABuild, Vec<ValidationError>> {
         let (base, oca_ast) = Self::parse_and_check_base(storage, ocafile)?;
@@ -172,7 +173,7 @@ impl Facade {
 
     pub fn build_from_ocafile(&mut self, ocafile: String) -> Result<OCABundle, Vec<Error>> {
         let oca_build = Self::validate_ocafile(
-            &self.db_cache,
+            self.db_cache.borrow(),
             ocafile,
             #[cfg(feature = "local-references")]
             &mut self.db,

--- a/oca/src/facade/fetch.rs
+++ b/oca/src/facade/fetch.rs
@@ -14,7 +14,7 @@ use said::SelfAddressingIdentifier;
 use serde::Serialize;
 #[cfg(feature = "local-references")]
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::{borrow::Borrow, rc::Rc};
 use std::str::FromStr;
 
 #[derive(Debug, Serialize)]
@@ -259,7 +259,7 @@ impl Facade {
         said: SelfAddressingIdentifier,
         with_dep: bool,
     ) -> Result<BundleWithDependencies, Vec<String>> {
-        get_oca_bundle(&self.db_cache, said, with_dep)
+        get_oca_bundle(self.db_cache.borrow(), said, with_dep)
     }
 
     pub fn get_oca_bundle_steps(
@@ -358,7 +358,7 @@ impl Facade {
 }
 
 pub fn get_oca_bundle(
-    storage: &Box<dyn DataStorage>,
+    storage: &dyn DataStorage,
     said: SelfAddressingIdentifier,
     with_dep: bool,
 ) -> Result<BundleWithDependencies, Vec<String>> {
@@ -377,7 +377,7 @@ pub fn get_oca_bundle(
             let mut dep_bundles = vec![];
             if with_dep {
                 for refs in retrive_all_references(oca_bundle.clone()) {
-                    let dep_bundle = get_oca_bundle(&storage, refs, true)?;
+                    let dep_bundle = get_oca_bundle(storage, refs, true)?;
                     dep_bundles.push(dep_bundle.bundle);
                     dep_bundles.extend(dep_bundle.dependencies);
                 }

--- a/oca/src/facade/fetch.rs
+++ b/oca/src/facade/fetch.rs
@@ -395,7 +395,7 @@ impl Facade {
                     local_refs.insert(k.clone(), String::from_utf8(v.to_vec()).unwrap());
                 });
             #[cfg(feature = "local-references")]
-            local_references::replace_refn_with_refs(&mut oca_ast, local_refs);
+            local_references::replace_refn_with_refs(&mut oca_ast, local_refs).map_err(|e| vec![e.to_string()])?;
         }
 
         Ok(oca_file::ocafile::generate_from_ast(&oca_ast))

--- a/oca/src/facade/mod.rs
+++ b/oca/src/facade/mod.rs
@@ -39,4 +39,8 @@ impl Facade {
             connection: Rc::new(conn),
         }
     }
+
+    pub fn storage<'a>(&self) -> &Box<dyn DataStorage> {
+        &self.db_cache
+    }
 }

--- a/oca/src/facade/mod.rs
+++ b/oca/src/facade/mod.rs
@@ -1,5 +1,6 @@
 use crate::data_storage::DataStorage;
 use crate::repositories::SQLiteConfig;
+use std::borrow::Borrow;
 use std::rc::Rc;
 
 pub mod build;
@@ -40,7 +41,7 @@ impl Facade {
         }
     }
 
-    pub fn storage<'a>(&self) -> &Box<dyn DataStorage> {
-        &self.db_cache
+    pub fn storage<'a>(&self) -> &dyn DataStorage {
+        self.db_cache.borrow()
     }
 }

--- a/oca/src/local_references.rs
+++ b/oca/src/local_references.rs
@@ -11,7 +11,10 @@ pub trait References {
 }
 
 // Iterate over all commands and dereference all attribute references
-pub fn replace_refn_with_refs<R: References>(oca_ast: &mut OCAAst, references: &R) -> Result<(), ValidationError> {
+pub fn replace_refn_with_refs<R: References>(
+    oca_ast: &mut OCAAst,
+    references: &R,
+) -> Result<(), ValidationError> {
     for command in oca_ast.commands.iter_mut() {
         if let (CommandType::Add, ObjectKind::CaptureBase(content)) =
             (&command.kind, &mut command.object_kind)
@@ -24,7 +27,7 @@ pub fn replace_refn_with_refs<R: References>(oca_ast: &mut OCAAst, references: &
                                 let said = SelfAddressingIdentifier::from_str(&said).unwrap(); // todo
                                 *attr_type = NestedAttrType::Reference(RefValue::Said(said));
                             } else {
-                                return Err(ValidationError::UnknownRefn(refn.clone()))
+                                return Err(ValidationError::UnknownRefn(refn.clone()));
                             }
                         }
                         NestedAttrType::Array(box_attr_type) => {
@@ -36,7 +39,7 @@ pub fn replace_refn_with_refs<R: References>(oca_ast: &mut OCAAst, references: &
                                     **box_attr_type =
                                         NestedAttrType::Reference(RefValue::Said(said));
                                 } else {
-                                    return Err(ValidationError::UnknownRefn(refn.clone()))
+                                    return Err(ValidationError::UnknownRefn(refn.clone()));
                                 }
                             }
                         }
@@ -45,6 +48,6 @@ pub fn replace_refn_with_refs<R: References>(oca_ast: &mut OCAAst, references: &
                 }
             }
         }
-    };
+    }
     Ok(())
 }

--- a/oca/src/local_references.rs
+++ b/oca/src/local_references.rs
@@ -1,12 +1,17 @@
-use std::{collections::HashMap, str::FromStr};
+use std::str::FromStr;
 
 use oca_ast::ast::{CommandType, NestedAttrType, OCAAst, ObjectKind, RefValue};
 use said::SelfAddressingIdentifier;
 
-use crate::facade::build::Error;
+use crate::facade::build::ValidationError;
+
+pub trait References {
+    fn find(&self, refn: &str) -> Option<String>;
+    fn save(&mut self, refn: &str, value: String);
+}
 
 // Iterate over all commands and dereference all attribute references
-pub fn replace_refn_with_refs(oca_ast: &mut OCAAst, references: HashMap<String, String>) -> Result<(), Error> {
+pub fn replace_refn_with_refs<R: References>(oca_ast: &mut OCAAst, references: &R) -> Result<(), ValidationError> {
     for command in oca_ast.commands.iter_mut() {
         if let (CommandType::Add, ObjectKind::CaptureBase(content)) =
             (&command.kind, &mut command.object_kind)
@@ -15,23 +20,23 @@ pub fn replace_refn_with_refs(oca_ast: &mut OCAAst, references: HashMap<String, 
                 for (_, attr_type) in attributes {
                     match attr_type {
                         NestedAttrType::Reference(RefValue::Name(refn)) => {
-                            if let Some(said) = references.get(refn) {
-                                let said = SelfAddressingIdentifier::from_str(said).unwrap(); // todo
+                            if let Some(said) = references.find(refn) {
+                                let said = SelfAddressingIdentifier::from_str(&said).unwrap(); // todo
                                 *attr_type = NestedAttrType::Reference(RefValue::Said(said));
                             } else {
-                                return Err(Error::UnknownRefn(refn.clone()))
+                                return Err(ValidationError::UnknownRefn(refn.clone()))
                             }
                         }
                         NestedAttrType::Array(box_attr_type) => {
                             if let NestedAttrType::Reference(RefValue::Name(refn)) =
                                 &**box_attr_type
                             {
-                                if let Some(said) = references.get(refn) {
-                                    let said = SelfAddressingIdentifier::from_str(said).unwrap(); // todo
+                                if let Some(said) = references.find(refn) {
+                                    let said = SelfAddressingIdentifier::from_str(&said).unwrap(); // todo
                                     **box_attr_type =
                                         NestedAttrType::Reference(RefValue::Said(said));
                                 } else {
-                                    return Err(Error::UnknownRefn(refn.clone()))
+                                    return Err(ValidationError::UnknownRefn(refn.clone()))
                                 }
                             }
                         }

--- a/oca/src/local_references.rs
+++ b/oca/src/local_references.rs
@@ -3,9 +3,11 @@ use std::{collections::HashMap, str::FromStr};
 use oca_ast::ast::{CommandType, NestedAttrType, OCAAst, ObjectKind, RefValue};
 use said::SelfAddressingIdentifier;
 
+use crate::facade::build::Error;
+
 // Iterate over all commands and dereference all attribute references
-pub fn replace_refn_with_refs(oca_ast: &mut OCAAst, references: HashMap<String, String>) {
-    oca_ast.commands.iter_mut().for_each(|command| {
+pub fn replace_refn_with_refs(oca_ast: &mut OCAAst, references: HashMap<String, String>) -> Result<(), Error> {
+    for command in oca_ast.commands.iter_mut() {
         if let (CommandType::Add, ObjectKind::CaptureBase(content)) =
             (&command.kind, &mut command.object_kind)
         {
@@ -17,7 +19,7 @@ pub fn replace_refn_with_refs(oca_ast: &mut OCAAst, references: HashMap<String, 
                                 let said = SelfAddressingIdentifier::from_str(said).unwrap(); // todo
                                 *attr_type = NestedAttrType::Reference(RefValue::Said(said));
                             } else {
-                                panic!("Reference not found: {}", refn);
+                                return Err(Error::UnknownRefn(refn.clone()))
                             }
                         }
                         NestedAttrType::Array(box_attr_type) => {
@@ -29,7 +31,7 @@ pub fn replace_refn_with_refs(oca_ast: &mut OCAAst, references: HashMap<String, 
                                     **box_attr_type =
                                         NestedAttrType::Reference(RefValue::Said(said));
                                 } else {
-                                    panic!("Reference not found: {}", refn);
+                                    return Err(Error::UnknownRefn(refn.clone()))
                                 }
                             }
                         }
@@ -38,5 +40,6 @@ pub fn replace_refn_with_refs(oca_ast: &mut OCAAst, references: HashMap<String, 
                 }
             }
         }
-    });
+    };
+    Ok(())
 }


### PR DESCRIPTION
Changes:
- separate validation logic from `Facade::build_from_ocafile` function,
- when `refn` is missing return error instead of panic,
- allow choosing a way of storing references names (add `References` trait).